### PR TITLE
Add kemal version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ authors:
 dependencies:
   kemal:
     github: sdogruyol/kemal
-    branch: master
+    version: 0.14.1
   dyncall:
     github: f/dyncall
     branch: master


### PR DESCRIPTION
Hi @f 

I'm using kreal for an experiment. but this shard only works until `crystal 0.18.7` and kemal `0.14.1`.

In the future would be good to support recents crystal versions, for now i'm using [crenv](https://github.com/pine/crenv)